### PR TITLE
Add a workflow to ensure the code builds whenever pushing to main

### DIFF
--- a/.github/workflows/build_main.yaml
+++ b/.github/workflows/build_main.yaml
@@ -1,0 +1,39 @@
+# This file describes a GitHub workflow to verify that the code compiles when updating the
+# main branch
+name: CI-main
+
+# Controls when the action will run. Triggers the workflow when pushing to the main branch or
+# when creating a pull request to the main branch.
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # This grabs the WPILib docker container. It will need to be updated for each season to ensure
+    # it is building with the correct season's wpilib code.
+    container: wpilib/roborio-cross-ubuntu:2023-22.04
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v3
+
+    # Declares the repository safe and not under dubious ownership.
+    - name: Add repository to git safe directories
+      run: git config --global --add safe.directory $GITHUB_WORKSPACE
+
+    # Grant execute permission for gradlew
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+
+    # Runs a single command using the runners shell
+    - name: Compile and run tests on robot code
+      run: ./gradlew build

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Smokey-XVI
+
+[![CI-main](https://github.com/bearbotics2358/Smokey-XVI/actions/workflows/build_main.yaml/badge.svg?branch=main)](https://github.com/bearbotics2358/Smokey-XVI/actions/workflows/build_main.yaml)
+
 Public code repository for our 2023 Charged Up Robot, competing at the Midwest Regional in Chicago, IL from March 8-11 and the Wisconsin Regional in Milwaukee, WI from March 22-25
 
 All code follows a must-build standard, as any programmers must successfully build code before pushing. This rule DOES NOT APPLY to branches labeled "experimental-"


### PR DESCRIPTION
This configures GitHub Actions to automatically build (and run tests if/when we can add some) on the robot code to provide some extra validation that code being pushed to main will still compile. This also runs when a Pull Request is created to be merged to main.

It seems like there is already a good team policy of verifying that code compiles before pushing anything, but having something like this would give everybody a little more confidence in the build status of the latest `main` branch.

I've added a few people as reviewers so you can take a look. If you think it's a good addition, you can approve the pull request and I'll merge it to `main`. 😄 