### PR TITLE
Rename CANCoder variable to m_CANCoder to avoid name collision

### DIFF
--- a/src/main/cpp/SwerveModule.cpp
+++ b/src/main/cpp/SwerveModule.cpp
@@ -12,7 +12,7 @@ steerMotor(steerID),
 driveEnc(driveMotor),
 steerEncFalcon(steerMotor),
 absSteerEnc(std::move(absEncoder)),
-CANCoder(CANCoderID),
+m_CANCoder(CANCoderID),
 steerPID(0, 0, 0) {
     // by default this selects the ingetrated sensor
     ctre::phoenix::motorcontrol::can::TalonFXConfiguration config;
@@ -54,7 +54,7 @@ void SwerveModule::resetSteerEncoder() {
 
 double SwerveModule::getRelativeAngle() {
     float temp = steerEncFalcon.GetIntegratedSensorPosition() * -1;
-    double CANticks = CANCoder.GetAbsolutePosition() * -1;
+    double CANticks = m_CANCoder.GetAbsolutePosition() * -1;
     //printf("%f\n",temp);
     float angle = (fmod(temp, 44000) / 44000) * 360; // convert to angle in degrees -- we were getting 44000 ticks per revolution
     //if (_steerID == 8){ printf("Raw Angle: %f\n",angle); } //TODO: Delete this
@@ -84,7 +84,7 @@ void SwerveModule::goToPosition(float meters) {
 void SwerveModule::steerToAng(float degrees) {
     float ticks = degrees / 360 * 44000;
     float trueticks = steerEncFalcon.GetIntegratedSensorPosition() * -1;
-    double CANticks = CANCoder.GetAbsolutePosition() * -1;
+    double CANticks = m_CANCoder.GetAbsolutePosition() * -1;
     float trueangle = (fmod(trueticks, 44000) / 44000) * 360;
     float speed = std::clamp(steerPID.Calculate(getAngle(), degrees) / 270.0, -0.5, 0.5);
     steerMotor.Set(TalonFXControlMode::PercentOutput, speed);
@@ -96,7 +96,7 @@ void SwerveModule::steerToAng(float degrees) {
 void SwerveModule::debugSteer(float angle) {
     float ticks = angle / 360 * 44000;
     float trueticks = steerEncFalcon.GetIntegratedSensorPosition() * -1;
-    double CANticks = CANCoder.GetAbsolutePosition() * -1;
+    double CANticks = m_CANCoder.GetAbsolutePosition() * -1;
     float trueangle = (fmod(trueticks, 44000) / 44000) * 360;
     if (_steerID == 8) { 
         printf("angle: %6.2f    trueangle: %6.2f   ticks: %6.2f  trueticks: %6.2f\n", angle, trueangle, ticks, trueticks); 

--- a/src/main/include/SwerveModule.h
+++ b/src/main/include/SwerveModule.h
@@ -77,7 +77,7 @@ class SwerveModule // Handles steering and driving of each Swerve Module
         TalonFXSensorCollection driveEnc; // built in TalonFX sensors
         TalonFXSensorCollection steerEncFalcon;
         AbsoluteEncoder absSteerEnc;
-        CANCoder CANCoder;
+        CANCoder m_CANCoder;
 
         frc2::PIDController steerPID;
 


### PR DESCRIPTION
Since CANCoder is the name of the class, the variable needs to be different so the compiler can know which one the code is trying to use. Any difference will do, but I renamed to `m_CANCoder` with `m_` indicating a member variable for the SwerveModule class.

This will get the code compiling again.