### PR TITLE
Make sure GetEncoder is only called one time

### DIFF
--- a/src/main/cpp/Arm.cpp
+++ b/src/main/cpp/Arm.cpp
@@ -7,13 +7,14 @@ a_armSolenoid(frc::PneumaticsModuleType::REVPH, pushSolenoidModule, pullSolenoid
 a_clawSolenoid(frc::PneumaticsModuleType::REVPH, openSolenoidModule, closeSolenoidModule),
 a_carriageMotor(carriageID, rev::CANSparkMaxLowLevel::MotorType::kBrushless),
 a_clawMotor(clawID, rev::CANSparkMaxLowLevel::MotorType::kBrushless),
-a_CANCoder(carriageCANCoderID) {
+a_CANCoder(carriageCANCoderID),
+a_carriageMotorEncoder(a_carriageMotor.GetEncoder()) {
     _CANCoderID = carriageCANCoderID - 17;
 }
 
 void Arm::updateDashboard(){
     frc::SmartDashboard::PutNumber("arm absolute encoder: ", getAngle());
-    frc::SmartDashboard::PutNumber("shuttle motor position: ", a_carriageMotor.GetEncoder().GetPosition());
+    frc::SmartDashboard::PutNumber("shuttle motor position: ", a_carriageMotorEncoder.GetPosition());
     if (a_armSolenoid.Get() == frc::DoubleSolenoid::Value::kReverse){
         frc::SmartDashboard::PutString("arm solenoid position: ", "reverse");
     } else if (a_armSolenoid.Get() == frc::DoubleSolenoid::Value::kForward){

--- a/src/main/include/Arm.h
+++ b/src/main/include/Arm.h
@@ -26,6 +26,7 @@ class Arm {
         rev::CANSparkMax a_carriageMotor;
         rev::CANSparkMax a_clawMotor;
         CANCoder a_CANCoder;
+        rev::SparkMaxRelativeEncoder a_carriageMotorEncoder;
         
         int _CANCoderID;
 };


### PR DESCRIPTION
@Milezoefif : Looks like since `updateDashboard()` is called multiple times, it still ends up calling `GetEncoder()` more than once. I just switched it to a class variable to resolve that.