### PR TITLE
Add macro to switch between practice and comp bot

### DIFF
--- a/src/main/cpp/Claw.cpp
+++ b/src/main/cpp/Claw.cpp
@@ -4,7 +4,9 @@
 
 Claw::Claw(int armMotorId, int shuttleMotorId, int pistonPushSolenoidModule, 
         int pistonPullSolenoidModule, int clawPushSolenoidModule, int clawPullSolenoidModule, 
-        int carriageCANCoderID, int limitSwitchId):
+        int carriageCANCoderID, int limitSwitchId)
+#ifdef COMP_BOT  // Not available on the practice bot
+:
 a_Piston(frc::PneumaticsModuleType::REVPH, pistonPushSolenoidModule, pistonPullSolenoidModule),
 a_ClawSolenoid(frc::PneumaticsModuleType::REVPH, clawPushSolenoidModule, clawPullSolenoidModule),
 armMotor(armMotorId, rev::CANSparkMaxLowLevel::MotorType::kBrushless),
@@ -14,7 +16,10 @@ shuttleEncoder(shuttleMotor.GetEncoder()),
 shuttleZeroSwitch(limitSwitchId),
 a_CANCoder(carriageCANCoderID),
 armPID(0.004,0,0), //pid set low to not ruin the robot, good speed is 0.007
-shuttlePID(0.002,0,0) { //good pid: 0.002
+shuttlePID(0.002,0,0)
+#endif
+{ //good pid: 0.002
+#ifdef COMP_BOT  // Not available on the practice bot
     armMotor.SetIdleMode(rev::CANSparkMax::IdleMode::kBrake);
 
     armPID.SetTolerance(15, 10);
@@ -28,6 +33,7 @@ shuttlePID(0.002,0,0) { //good pid: 0.002
     shuttleMotor.StopMotor();
 
     a_CANCoder.ConfigMagnetOffset(CANCODER_OFFSET_ARM);
+#endif
 }
 
 void Claw::clawInit() {
@@ -35,13 +41,16 @@ void Claw::clawInit() {
 }
 
 void Claw::UpdateShuttleEncoder(){
+#ifdef COMP_BOT  // Not available on the practice bot
     if (shuttleZeroSwitch.limitSwitchPressed() == true){
         shuttleEncoder.SetPosition(0);
     }
+#endif
 }
 
 
 void Claw::updateDashboard(){
+#ifdef COMP_BOT  // Not available on the practice bot
     frc::SmartDashboard::PutNumber("arm absolute encoder: ", getAngle());
     frc::SmartDashboard::PutNumber("shuttle motor position: ", shuttleEncoder.GetPosition());
     frc::SmartDashboard::PutNumber("shuttle position (mm): ", GetShuttlePositionMM());
@@ -53,75 +62,110 @@ void Claw::updateDashboard(){
     } else {
         frc::SmartDashboard::PutString("arm solenoid position: ", "off");
     }
+#endif
     
 }
 
 void Claw::StopShuttle(){
+#ifdef COMP_BOT  // Not available on the practice bot
     shuttleMotor.StopMotor();
+#endif
 }
 
 void Claw::StopArm(){
+#ifdef COMP_BOT  // Not available on the practice bot
     armMotor.StopMotor();
+#endif
 }
 
 double Claw::getAngle(){
+#ifdef COMP_BOT  // Not available on the practice bot
     return a_CANCoder.GetAbsolutePosition();
+#else
+    return 0.0;
+#endif
 }
 
 
 void Claw::setSolenoid(bool deployed) {
+#ifdef COMP_BOT  // Not available on the practice bot
     if (deployed) {
         a_Piston.Set(frc::DoubleSolenoid::Value::kReverse);
     } else {
         a_Piston.Set(frc::DoubleSolenoid::Value::kForward);
     }
+#endif
 }
 
 // MANY OF THESE ARE MANUAL, WILL BE REPLACED WITH AUTOMATION
 void Claw::ArmPistonUp(){
+#ifdef COMP_BOT  // Not available on the practice bot
     a_Piston.Set(frc::DoubleSolenoid::Value::kForward);
+#endif
 }
 
 void Claw::ArmPistonDown(){
+#ifdef COMP_BOT  // Not available on the practice bot
     a_Piston.Set(frc::DoubleSolenoid::Value::kReverse);
+#endif
 }
 
 void Claw::ArmMotorUp(){
+#ifdef COMP_BOT  // Not available on the practice bot
     armMotor.Set(0.1);
+#endif
 }
 
 void Claw::ArmMotorDown(){
+#ifdef COMP_BOT  // Not available on the practice bot
     armMotor.Set(-0.1);
+#endif
 }
 
 void Claw::ClawOpen(){
+#ifdef COMP_BOT  // Not available on the practice bot
     a_ClawSolenoid.Set(frc::DoubleSolenoid::Value::kReverse);
+#endif
 }
 
 void Claw::ClawClose(){
+#ifdef COMP_BOT  // Not available on the practice bot
     a_ClawSolenoid.Set(frc::DoubleSolenoid::Value::kForward);
+#endif
 }
 
 void Claw::ShuttleMotorUp() {
+#ifdef COMP_BOT  // Not available on the practice bot
     shuttleMotor.Set(0.1);
+#endif
 }
 
 void Claw::ShuttleMotorDown() {
+#ifdef COMP_BOT  // Not available on the practice bot
     shuttleMotor.Set(-0.1);
+#endif
 }
 
 double Claw::GetShuttlePositionMM() {
+#ifdef COMP_BOT  // Not available on the practice bot
     double ret;
 
     ret = shuttleEncoder.GetPosition() / SHUTTLE_TICKS_PER_MM;
     return ret;
+#else
+    return 0.0;
+#endif
 }
 
 double Claw::GetShuttlePositionInches() {
+#ifdef COMP_BOT  // Not available on the practice bot
     double ret;
 
     ret = GetShuttlePositionMM() / 25.4;
     return ret;
+#else
+    return 0.0;
+#endif
 }
 
 bool Claw::IsShuttleSafeToMove(){ // shuttle is safe to move as long as the arm is within a certain range
@@ -133,6 +177,7 @@ bool Claw::IsShuttleSafeToMove(){ // shuttle is safe to move as long as the arm 
 }
 
 bool Claw::ShuttleMoveToMM(double targetPosition) {
+#ifdef COMP_BOT  // Not available on the practice bot
     currentShuttleAngle = targetPosition;
     double motorDrive = shuttlePID.Calculate(GetShuttlePositionMM(), targetPosition);
     shuttlePID.SetSetpoint(targetPosition);
@@ -142,16 +187,24 @@ bool Claw::ShuttleMoveToMM(double targetPosition) {
         shuttleMotor.Set(motorDrive);
     }
     return shuttlePID.AtSetpoint();
+#else
+    return true;
+#endif
 }
 
 bool Claw::ShuttleHold(){
+#ifdef COMP_BOT  // Not available on the practice bot
     bool ret = false;
 
     ret = ShuttleMoveToMM(currentShuttleAngle);
     return ret;
+#else
+    return true;
+#endif
 }
 
 bool Claw::ArmMoveTo(double targetPosition) {
+#ifdef COMP_BOT  // Not available on the practice bot
     currentArmAngle = targetPosition;
     targetPosition = std::clamp(targetPosition, 5.0, 175.0);
     double motorDrive = armPID.Calculate(getAngle(), targetPosition);
@@ -160,17 +213,25 @@ bool Claw::ArmMoveTo(double targetPosition) {
     frc::SmartDashboard::PutNumber("arm pid: ", motorDrive);
     armMotor.Set(motorDrive);
     return armPID.AtSetpoint();
+#else
+    return true;
+#endif
 }
 
 bool Claw::ArmHold(){
+#ifdef COMP_BOT  // Not available on the practice bot
     bool ret = false;
 
     ret = ArmMoveTo(currentArmAngle);
     return ret;
+#else
+    return true;
+#endif
 }
 
 bool Claw::TransformClaw(double desiredAngle, double desiredShuttle, bool extend){
 
+#ifdef COMP_BOT  // Not available on the practice bot
     if (extend == false){
         a_Piston.Set(frc::DoubleSolenoid::Value::kReverse); // retract piston if needed
     }
@@ -189,6 +250,9 @@ bool Claw::TransformClaw(double desiredAngle, double desiredShuttle, bool extend
     }
 
     return false;
+#else
+    return true;
+#endif
 }
 
 void Claw::HoldClaw(){

--- a/src/main/cpp/CompressorController.cpp
+++ b/src/main/cpp/CompressorController.cpp
@@ -1,23 +1,32 @@
 #include "CompressorController.h"
 #include <frc/smartdashboard/SmartDashboard.h>
 
-CompressorController::CompressorController():
-a_Compressor(frc::PneumaticsModuleType::REVPH) 
+CompressorController::CompressorController()
+#ifdef COMP_BOT  // Not available on the practice bot
+:
+a_Compressor(frc::PneumaticsModuleType::REVPH)
+#endif
 {
     
 }
 
 void CompressorController::update(){
+#ifdef COMP_BOT  // Not available on the practice bot
     if (a_Compressor.GetPressureSwitchValue() == false) {
         a_Compressor.Disable();
     } else {
         a_Compressor.EnableDigital();
     }
     frc::SmartDashboard::PutNumber("compressor pressure: ", getTankPressure());
+#endif
 }
 
 double CompressorController::getTankPressure(){
+#ifdef COMP_BOT  // Not available on the practice bot
     return a_Compressor.GetPressure().value();
+#else
+    return 0.0;
+#endif
 }
 
 /*  CompressorController Ideas
@@ -25,5 +34,7 @@ double CompressorController::getTankPressure(){
 */
 
 void CompressorController::turnOff() {
+#ifdef COMP_BOT  // Not available on the practice bot
     a_Compressor.Disable();
+#endif
 }

--- a/src/main/cpp/Gyro.cpp
+++ b/src/main/cpp/Gyro.cpp
@@ -38,33 +38,6 @@ void Gyro::Update() {
 
     frc::SmartDashboard::PutNumber("gyro angle: ", getAngle());
     frc::SmartDashboard::PutNumber("gyro angle clamped: ", getAngleClamped());
-    /*
-    if (lastUpdate == 0) {
-        lastUpdate = frc::Timer::GetFPGATimestamp().value();
-        return;
-    }
-    double time = frc::Timer::GetFPGATimestamp().value();
-    double timeDelta = (time - lastUpdate);
-
-    double storeAngles[3];
-
-    a_PigeonIMU.GetAccelerometerAngles(storeAngles);
-
-    XAxis = storeAngles[0];
-    XAxis = XAxis / 14.375;
-
-    YAxis = storeAngles[1];
-    YAxis = YAxis / 14.375;
-
-    ZAxis = storeAngles[2];
-    ZAxis = ZAxis / 14.375;
-
-    angle[0] += ((XAxis - angleBias[0]) * timeDelta);
-    angle[1] += ((YAxis - angleBias[1]) * timeDelta);
-    angle[2] += ((ZAxis - angleBias[2]) * timeDelta);
-
-    lastUpdate = time;
-    */
 }
 
 double Gyro::getAngle() const {

--- a/src/main/cpp/LED.cpp
+++ b/src/main/cpp/LED.cpp
@@ -7,8 +7,11 @@
 #include <Prefs.h>
 #include "LED.h"
 
-LED::LED():
+LED::LED()
+#ifdef COMP_BOT  // Not available on the practice bot
+:
 	m_serial(BAUD_RATE_ARDUINO, USB_PORT_ARDUINO, DATA_BITS_ARDUINO, PARITY_ARDUINO, STOP_BITS_ARDUINO)
+#endif
 	// comments from 2018:
 	// USB1 is the onboard port closest to the center of the rio
 	// I dunno which one USB2 is yet. (Rio docs aren't very helpful)
@@ -30,6 +33,7 @@ void LED::Init()
 
 void LED::Update()
 {
+#ifdef COMP_BOT  // Not available on the practice bot
 	// call this routine periodically to check for any readings and store
 	// into result registers
 
@@ -69,6 +73,7 @@ void LED::Update()
 			}
 		}
 	}
+#endif
 }
 
 // instead of atoi(), UltrasonicSerial used strtol(&readBuffer[1], (char **)NULL, 10);
@@ -82,6 +87,7 @@ void LED::ProcessReport()
 
 void LED::SetTargetType(target_type_enum target_type_param)
 {
+#ifdef COMP_BOT  // Not available on the practice bot
 	char cmd[10];
 	strncpy(cmd, "1,1,1\r\n", 8);
 	target_type = target_type_param;
@@ -89,6 +95,7 @@ void LED::SetTargetType(target_type_enum target_type_param)
 	cmd[4] = target_type ? '1' : '0';
 	m_serial.Write(cmd, strlen(cmd));
 	m_serial.Flush();
+#endif
 }
 
 target_type_enum LED::GetTargetType()

--- a/src/main/cpp/Robot.cpp
+++ b/src/main/cpp/Robot.cpp
@@ -57,6 +57,12 @@ a_LED(ARDUINO_DIO_PIN)
 
 void Robot::RobotInit() {
     frc::SmartDashboard::init();
+
+#ifndef COMP_BOT
+    // using #ifndef here to indicate when this is the practice bot
+    frc::SmartDashboard::PutString("Bot type", "PRACTICE BOT");
+#endif
+
     a_Gyro.Init();
     a_Gyro.Zero();
 

--- a/src/main/cpp/SwerveModule.cpp
+++ b/src/main/cpp/SwerveModule.cpp
@@ -19,7 +19,16 @@ steerPID(0, 0, 0) {
     _steerID = steerID;
     _CANCoderID = CANCoderID - 17;
 
+#ifdef COMP_BOT  // Only needs to be inverted on the comp bot
     steerMotor.SetInverted(true);
+
+    // For the comp bot, angle values don't need to be changed
+    m_inversionFactor = 1.0;
+#else
+    // For the practice bot, angle values must be negated
+    // @todo: Why does this need to be different for the practice bot?
+    m_inversionFactor = -1.0;
+#endif
 
     // these settings are present in the documentation example, and since they relate to safety of motor, they are probably a good idea to include
     config.supplyCurrLimit.triggerThresholdCurrent = 40; // the peak supply current, in amps
@@ -48,7 +57,7 @@ void SwerveModule::resetDriveEncoder() {
 
 double SwerveModule::getRelativeAngle() {
     //float temp = steerEncFalcon.GetIntegratedSensorPosition() * -1;
-    double angle = m_CANCoder.GetAbsolutePosition() - CANCODER_OFFSETS[_CANCoderID];
+    double angle = (m_CANCoder.GetAbsolutePosition() - CANCODER_OFFSETS[_CANCoderID]) * m_inversionFactor;
     //printf("%f\n",temp);
     //float angle = (fmod(angle, 44000) / 44000) * 360; // convert to angle in degrees -- we were getting 44000 ticks per revolution
     //if (_steerID == 8){ printf("Raw Angle: %f\n",angle); } //TODO: Delete this
@@ -64,7 +73,7 @@ double SwerveModule::getRelativeAngle() {
 
 float SwerveModule::getAngle() {
     if((_CANCoderID + 17) == misc::GetFLCANCoder()) {
-        double position = m_CANCoder.GetAbsolutePosition() - CANCODER_OFFSETS[_CANCoderID];
+        double position = (m_CANCoder.GetAbsolutePosition() - CANCODER_OFFSETS[_CANCoderID]) * m_inversionFactor;
         //printf("position: %6.2f \n", position);
     }
     return misc::clampDegrees(getRelativeAngle() + encZeroPoint);
@@ -76,27 +85,12 @@ void SwerveModule::goToPosition(float meters) {
 }
 
 void SwerveModule::steerToAng(float degrees) {
-    float ticks = degrees / 360 * 44000;
-    //float trueticks = steerEncFalcon.GetIntegratedSensorPosition() * -1;
-    double CANticks = m_CANCoder.GetAbsolutePosition() - CANCODER_OFFSETS[_CANCoderID];
-    //float trueangle = (fmod(trueticks, 44000) / 44000) * 360;
     float speed = std::clamp(steerPID.Calculate(getAngle(), degrees) / 270.0, -0.5, 0.5);
     steerMotor.Set(TalonFXControlMode::PercentOutput, speed);
     // if(_CANCoderID == misc::GetBLCANCoder()) {
     //     int position = m_CANCoder.GetAbsolutePosition();
     //     printf("position: %6.2f \n", position);
     // }
-}
-
-void SwerveModule::debugSteer(float angle) {
-    float ticks = angle / 360 * 44000;
-    float trueticks = steerEncFalcon.GetIntegratedSensorPosition() * -1;
-    double CANticks = m_CANCoder.GetAbsolutePosition() - CANCODER_OFFSETS[_CANCoderID];
-    float trueangle = (fmod(trueticks, 44000) / 44000) * 360;
-    // if (_steerID == 5) { 
-    //     printf("angle: %6.2f    trueangle: %6.2f   ticks: %6.2f  trueticks: %6.2f\n", angle, trueangle, ticks, trueticks); 
-    // }
-    steerMotor.Set(TalonFXControlMode::Position, angle);
 }
 
 void SwerveModule::setDrivePercent(float percent) {

--- a/src/main/cpp/TOF.cpp
+++ b/src/main/cpp/TOF.cpp
@@ -9,8 +9,11 @@
 #include "TOF.h"
 #include <frc/smartdashboard/SmartDashboard.h>
 
-TOF::TOF():
+TOF::TOF()
+#ifdef COMP_BOT  // Not available on the practice bot
+:
 	m_serial(BAUD_RATE_TOF, USB_PORT_TOF, DATA_BITS_TOF, PARITY_TOF, STOP_BITS_TOF)
+#endif
 	// comments from 2018:
 	// USB1 is the onboard port closest to the center of the rio
 	// I dunno which one USB2 is yet. (Rio docs aren't very helpful)
@@ -34,6 +37,7 @@ void TOF::Init()
 
 void TOF::Update()
 {
+#ifdef COMP_BOT  // Not available on the practice bot
 	// call this routine periodically to check for any readings and store
 	// into result registers
 
@@ -74,6 +78,7 @@ void TOF::Update()
       }
     }
   }
+#endif
 }
 
 // instead of atoi(), UltrasonicSerial used strtol(&readBuffer[1], (char **)NULL, 10);
@@ -126,6 +131,7 @@ float TOF::GetInches()
 
 void TOF::SetTargetType(target_type_enum target_type_param)
 {
+#ifdef COMP_BOT  // Not available on the practice bot
 	char cmd[8];
 	strncpy(cmd, "1,1,1\r\n", 8);
 	target_type = target_type_param;
@@ -133,6 +139,7 @@ void TOF::SetTargetType(target_type_enum target_type_param)
 	cmd[4] = target_type ? '1' : '0';
 	m_serial.Write(cmd, strlen(cmd));
 	m_serial.Flush();
+#endif
 }
 
 target_type_enum TOF::GetTargetType()
@@ -142,18 +149,22 @@ target_type_enum TOF::GetTargetType()
 
 void TOF::EnableHistogram(int enable)
 {
+#ifdef COMP_BOT  // Not available on the practice bot
 	char cmd[8];
 	strncpy(cmd, "2,1,1\r\n", 8);
 	cmd[4] = enable ? '1' : '0';
 	m_serial.Write(cmd, strlen(cmd));
 	m_serial.Flush();
+#endif
 }
 
 void TOF::EnableRawPixelData(int enable)
 {
+#ifdef COMP_BOT  // Not available on the practice bot
 	char cmd[8];
 	strncpy(cmd, "4,1,1\r\n", 8);
 	cmd[4] = enable ? '1' : '0';
 	m_serial.Write(cmd, strlen(cmd));
 	m_serial.Flush();
+#endif
 }

--- a/src/main/include/Claw.h
+++ b/src/main/include/Claw.h
@@ -10,8 +10,8 @@
 class Claw {
     public:
         Claw(int armMotorId, int shuttleMotorId, int pistonPushSolenoidModule, 
-        int pistonPullSolenoidModule, int clawPushSolenoidModule, 
-        int clawPullSolenoidModule, int carriageCANCoder, int limitSwitchId);
+                int pistonPullSolenoidModule, int clawPushSolenoidModule, 
+                int clawPullSolenoidModule, int carriageCANCoder, int limitSwitchId);
         bool TransformClaw(double angle, double shuttle, bool extend);
         void HoldClaw();
         void clawInit();
@@ -39,6 +39,7 @@ class Claw {
         bool IsArmPIDAtSetpoint();
         bool IsShuttlePIDAtSetpoint();
     private:
+#ifdef COMP_BOT  // Not available on the practice bot
         frc::DoubleSolenoid a_Piston;
         frc::DoubleSolenoid a_ClawSolenoid;
         rev::CANSparkMax shuttleMotor;
@@ -55,4 +56,5 @@ class Claw {
 
         frc2::PIDController armPID;
         frc2::PIDController shuttlePID;
+#endif
 };

--- a/src/main/include/CompressorController.h
+++ b/src/main/include/CompressorController.h
@@ -11,6 +11,8 @@ class CompressorController {
         void turnOff();
 
     private:
+#ifdef COMP_BOT  // Not available on the practice bot
         frc::Compressor a_Compressor;
+#endif
 
 };

--- a/src/main/include/LED.h
+++ b/src/main/include/LED.h
@@ -26,7 +26,9 @@ public:
 	target_type_enum GetTargetType();
 
 private:
+#ifdef COMP_BOT  // Not available on the practice bot
 	frc::SerialPort m_serial;
+#endif
 	char rx_buff[BUFF_SIZE];
 	int rx_index = 0;
 	target_type_enum target_type = target_type_enum::CONE;

--- a/src/main/include/Prefs.h
+++ b/src/main/include/Prefs.h
@@ -10,7 +10,15 @@
 // uncomment to enable the new swerve
 //#define NEW_SWERVE
 
+// For the competition bot, this line *MUST* be enabled. For the practice bot, comment out this line.
+#define COMP_BOT
+
+#ifdef COMP_BOT  // The comp bot and the practice bot have some different IDs for various components
 #define GYRO_ID 1
+#else
+#define GYRO_ID 35
+#endif
+
 #define PISTON_PUSH_SOLENOID_MODULE 10
 #define PISTON_PULL_SOLENOID_MODULE 11
 #define CLAW_OPEN_SOLENOID_MODULE 12
@@ -42,10 +50,17 @@ m = number engraved on module
 
 */
 
+#ifdef COMP_BOT  // The comp bot and the practice bot have some different IDs for various components
 #define FL_ID 8
 #define FR_ID 4
 #define BL_ID 5
 #define BR_ID 3
+#else
+#define FL_ID 1
+#define FR_ID 6
+#define BL_ID 7
+#define BR_ID 2
+#endif
 
 
 /*======= ENCODER CONSTANTS =======*/

--- a/src/main/include/SwerveModule.h
+++ b/src/main/include/SwerveModule.h
@@ -73,4 +73,6 @@ class SwerveModule // Handles steering and driving of each Swerve Module
         // how many degrees away from the actual zero degrees
         // that the relative encoder's zero point is
         double encZeroPoint { 0.0 };
+
+        double m_inversionFactor = 1.0;
 };

--- a/src/main/include/TOF.h
+++ b/src/main/include/TOF.h
@@ -32,7 +32,9 @@ class TOF
 	float GetInches();
 
  private:
+#ifdef COMP_BOT  // Not available on the practice bot
 	frc::SerialPort m_serial;
+#endif
 	char rx_buff[BUFF_SIZE];
 	int rx_index = 0;
 	int range = 9999; // range in mm


### PR DESCRIPTION
Instead of trying to maintain a separate `Practice-Bot-Drive` branch and running the risk of missing things switching between branches for the practice bot versus competition bot, I wanted to bring the code back together so both bots can be run off of `main` with just a change to a macro.

Some of these changes may not be necessary to keep the practice bot and competition bot isolated, but they are what seemed to be required from the branch to avoid compiling the parts of the code that talk to components that are not installed on the practice bot. It's not exactly pretty since there are `#ifdef COMP_BOT` lines everywhere, but it's better than managing multiple branches with a bunch of lines commented out. 😄 

Maybe Friday we can try deploying this branch on the practice bot to verify that it works. Then we can separately bring in the other changes for Autonomous that are also hanging out on the `Practice-Bot-Drive` branch.